### PR TITLE
ci: migrate to canonical docker-build reusable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,17 @@
+name: Docker
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev, test]
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    uses: hanzoai/.github/.github/workflows/docker-build.yml@main
+    with:
+      image: ghcr.io/luxfi/market
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,86 +1,31 @@
 name: Docker
-
 on:
   push:
-    branches: [main]
-    tags: ['v*']
-  workflow_dispatch:
-
+    branches:
+    - main
+    tags:
+    - v*
+  workflow_dispatch: null
 permissions:
   contents: write
   packages: write
-
 jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Compute + tag version (v1.x.x — no major bumps)
-        id: bump
-        run: |
-          set -e
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            LAST=$(git tag -l 'v1.*' --sort=-v:refname | head -1)
-            if [ -z "$LAST" ]; then
-              NEW="1.0.0"
-            else
-              MINOR=$(echo "${LAST#v1.}" | cut -d. -f1)
-              PATCH=$(echo "${LAST#v1.}" | cut -d. -f2)
-              MSG=$(git log -1 --pretty=%s)
-              # feat: or BREAKING → minor bump, else → patch bump
-              # NO MAJOR BUMPS — capped at v1.x.x
-              if [[ "$MSG" =~ ^(feat|BREAKING|[a-z]+!) ]]; then
-                NEW="1.$((MINOR+1)).0"
-              else
-                NEW="1.$MINOR.$((PATCH+1))"
-              fi
-            fi
-            VERSION="$NEW"
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git tag "v$VERSION" || true
-            git push origin "v$VERSION" || echo "tag push skipped"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "VERSION=$VERSION"
-
-  build-push:
-    needs: version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=main,enable={{is_default_branch}}
-            type=raw,value=v${{ needs.version.outputs.version }}
-            type=raw,value=${{ needs.version.outputs.version }}
-            type=sha,prefix=,suffix=,format=short
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: true
+    - name: "Compute + tag version (v1.x.x \u2014 no major bumps)"
+      id: bump
+      run: "set -e\nif [[ \"${GITHUB_REF}\" == refs/tags/v* ]]; then\n  VERSION=\"${GITHUB_REF#refs/tags/v}\"\nelse\n  LAST=$(git\
+        \ tag -l 'v1.*' --sort=-v:refname | head -1)\n  if [ -z \"$LAST\" ]; then\n    NEW=\"1.0.0\"\n  else\n    MINOR=$(echo\
+        \ \"${LAST#v1.}\" | cut -d. -f1)\n    PATCH=$(echo \"${LAST#v1.}\" | cut -d. -f2)\n    MSG=$(git log -1 --pretty=%s)\n\
+        \    # feat: or BREAKING \u2192 minor bump, else \u2192 patch bump\n    # NO MAJOR BUMPS \u2014 capped at v1.x.x\n\
+        \    if [[ \"$MSG\" =~ ^(feat|BREAKING|[a-z]+!) ]]; then\n      NEW=\"1.$((MINOR+1)).0\"\n    else\n      NEW=\"1.$MINOR.$((PATCH+1))\"\
+        \n    fi\n  fi\n  VERSION=\"$NEW\"\n  git config user.name 'github-actions[bot]'\n  git config user.email 'github-actions[bot]@users.noreply.github.com'\n\
+        \  git tag \"v$VERSION\" || true\n  git push origin \"v$VERSION\" || echo \"tag push skipped\"\nfi\necho \"version=$VERSION\"\
+        \ >> \"$GITHUB_OUTPUT\"\necho \"VERSION=$VERSION\"\n"

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,0 +1,9 @@
+name: Workflow Sanity
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  sanity:
+    uses: hanzoai/.github/.github/workflows/workflow-sanity.yml@main


### PR DESCRIPTION
## Summary

Migrate to canonical Docker CI:
- Add `.github/workflows/docker.yml` using `hanzoai/.github/.github/workflows/docker-build.yml@main`
- Add `.github/workflows/workflow-sanity.yml` enforcing the canonical CI contract
- Remove bespoke `docker/build-push-action` usage

Image: `ghcr.io/luxfi/market`

## Test plan
- [ ] Workflow Sanity passes (no bespoke docker build, no GitHub-hosted runners, no stale labels)
- [ ] Canonical Docker workflow runs on push to main
- [ ] Produces multi-arch images (amd64 + arm64) on ARC runners